### PR TITLE
fix(profiles): render single profiles through the theme template

### DIFF
--- a/includes/FrontEnd/FrontEnd.php
+++ b/includes/FrontEnd/FrontEnd.php
@@ -58,6 +58,9 @@ class FrontEnd {
 	 */
 	public function hooks(): void {
 		add_filter( 'newspack_can_show_post_thumbnail', [ __CLASS__, 'newspack_can_show_post_thumbnail' ], 10, 1 );
+		add_filter( 'body_class', [ __CLASS__, 'body_class' ] );
+		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
+		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_front_end_style' ], 10, 0 );
 
 		add_action( 'govpack_before_main_content', [ $this, 'output_wrapper_start' ] );
@@ -104,6 +107,67 @@ class FrontEnd {
 		wp_enqueue_style( 'govpack-block-styles' );
 	}
 
+
+	/**
+	 * Alias the page-template body class to the one Newspack's themes style.
+	 *
+	 * Their CSS keys on `post-template-*`; WordPress emits
+	 * `govpack_profiles-template-*`. Newspack Listings aliases the same.
+	 *
+	 * @param string[] $classes Body classes.
+	 * @return string[]
+	 */
+	public static function body_class( array $classes ): array {
+
+		if ( ! is_singular( \Govpack\Profile\CPT::CPT_SLUG ) ) {
+			return $classes;
+		}
+
+		$template = get_page_template_slug();
+
+		if ( 'single-feature.php' === $template ) {
+			$classes[] = 'post-template-single-feature';
+		} elseif ( 'single-wide.php' === $template ) {
+			$classes[] = 'post-template-single-wide';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Hide the publish date on a profile.
+	 *
+	 * The date records when the profile was entered, not anything about its
+	 * subject.
+	 *
+	 * @param bool $hide Whether the date is hidden.
+	 * @return bool
+	 */
+	public static function hide_publish_date( $hide ): bool {
+
+		if ( \Govpack\Profile\CPT::CPT_SLUG === get_post_type() ) {
+			return true;
+		}
+
+		return (bool) $hide;
+	}
+
+	/**
+	 * Hide the byline and author bio on a profile.
+	 *
+	 * A profile's author is whoever entered the record, not its subject.
+	 *
+	 * @param bool $hide Whether the author is hidden.
+	 * @return bool
+	 */
+	public static function hide_author( $hide ): bool {
+
+		if ( \Govpack\Profile\CPT::CPT_SLUG === get_post_type() ) {
+			return true;
+		}
+
+		return (bool) $hide;
+	}
 
 	/**
 	 * Filter newspack Templates to show thumbnails

--- a/includes/TemplateLoader.php
+++ b/includes/TemplateLoader.php
@@ -69,11 +69,45 @@ class TemplateLoader extends \Govpack_Vendor_Gamajo_Template_Loader {
 			return $template;
 		}
 
-		if ( is_singular( \Govpack\Profile\CPT::CPT_SLUG ) ) {
-			return $this->locate_template( \Govpack\Profile\CPT::TEMPLATE_NAME );
+		if ( ! is_singular( \Govpack\Profile\CPT::CPT_SLUG ) ) {
+			return $template;
 		}
 
-		return $template;
+		$located = $this->locate_template( \Govpack\Profile\CPT::TEMPLATE_NAME );
+
+		// A theme copy under govpack/ is an explicit opt-in; it outranks both.
+		if ( $located && 0 !== strpos( $located, $this->plugin_directory ) ) {
+			return $located;
+		}
+
+		if ( $this->theme_handles_single_profile( $template ) ) {
+			return $template;
+		}
+
+		return $located;
+	}
+
+	/**
+	 * Whether to leave the profile for the theme to render.
+	 *
+	 * True for every classic theme with a single.php. The bundle renders outside
+	 * the column themes constrain article text to, and replaces an editor-chosen
+	 * page template.
+	 *
+	 * @param string $template Template the hierarchy resolved to.
+	 * @return bool
+	 */
+	private function theme_handles_single_profile( $template ): bool {
+
+		$handles = ! empty( $template ) && 'index.php' !== basename( $template );
+
+		/**
+		 * Filters whether the theme renders a single profile in place of the bundled template.
+		 *
+		 * @param bool   $handles  Whether the theme renders the profile.
+		 * @param string $template Template the hierarchy resolved to.
+		 */
+		return (bool) apply_filters( 'govpack_theme_handles_single_profile', $handles, $template );
 	}
 
 	private function do_render( string $template, array $attributes = [], string $content = '', mixed $block = null, mixed $extra = null ): string {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-workspace/blob/main/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A single profile was rendered by the bundled template, which sits outside the column a theme constrains article text to, so profile copy ran the full container width. It also replaced whatever the hierarchy had resolved, including a page template chosen in the editor.

The plugin now stands aside when the hierarchy resolves to anything more specific than `index.php`, which is every classic theme with a `single.php`. A profile then renders like a post, and an editor-chosen template takes effect. A theme's own copy under `govpack/` still wins, and the bundled template remains the fallback behind the new `govpack_theme_handles_single_profile` filter.

Supporting changes: profiles now carry the generic `post-template-*` body class that Newspack's themes style their page templates against, matching what Newspack Listings does; and the byline, author bio, and publish date are hidden, since each describes the record rather than the person it profiles.

Rendering through the theme replaces the bundled markup, so the `govpack_before_main_content`, `govpack_sidebar`, and `govpack_after_main_content` hooks no longer fire on a single profile. The filter above restores the old path for a site that needs it.

Closes [NPPM-3247](https://linear.app/a8c/issue/NPPM-3247).

### How to test the changes in this Pull Request:

1. Activate this branch on a site running a classic Newspack theme.
2. Create a profile with two or three paragraphs of body text. Publish it.
3. View it. Body text sits in the same column width as a regular post.
4. Confirm no byline, author bio, or publish date appears.
5. Add a Homepage Posts block to the profile. Bylines inside that block still render.
6. With Automattic/newspack-workspace#1039 also applied, set Template to One column wide. Text expands to the full container width.
7. Set Template to One column. The sidebar is dropped and the article width returns.
8. Copy `templates/single-govpack-profiles.php` to `yourtheme/govpack/`. That copy renders instead.
9. Remove it, then add `add_filter( 'govpack_theme_handles_single_profile', '__return_false' );` in a mu-plugin. The bundled template renders again.
10. Remove the mu-plugin and switch to a block theme. Rendering is unchanged from before this branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

This repo has no PHPUnit suite and no PR CI. Verified by hand across all three template options, a theme override, the filter fallback, and a block theme. PHPCS adds no new violations.
