### PR TITLE
fix(profiles): escape profile field output at the point of render

### DIFF
--- a/includes/govpack-functions-template.php
+++ b/includes/govpack-functions-template.php
@@ -162,19 +162,24 @@ if ( ! function_exists( 'gp_style_attribute_generator' ) ) {
 }
 
 /**
- * Utility Function that conditionally Outputs a link to a profile around some other content
- * 
- * @param string  $content The content to wrap with a link.
+ * Utility Function that conditionally Outputs a link to a profile around some other content.
+ *
+ * Takes plain text and returns HTML that is safe to echo: the content is
+ * escaped on every path, linked or not, so a caller never has to know which
+ * branch it took. Pass text, not markup.
+ *
+ * @param string  $content The plain-text content to wrap with a link.
  * @param string  $url The URL to link to.
  * @param boolean $use_link Condition control, outputs link if true.
+ * @return string Escaped HTML.
  */
 if ( ! function_exists( 'gp_maybe_link' ) ) {
-	function gp_maybe_link( string $content, string $url, bool $use_link ) {
+	function gp_maybe_link( string $content, string $url, bool $use_link ): string {
 
 		if ( ! $use_link ) {
-			return $content;
+			return esc_html( $content );
 		}
-		return '<a href=' . esc_url( $url ) . '>' . $content . '</a>';
+		return '<a href="' . esc_url( $url ) . '">' . esc_html( $content ) . '</a>';
 	}
 }
 

--- a/includes/govpack-functions-template.php
+++ b/includes/govpack-functions-template.php
@@ -383,19 +383,32 @@ if ( ! function_exists( 'esc_svg' ) ) {
 			$svg_string,
 			[
 				'svg'      => [
-					'xmlns'   => [], 
-					'width'   => [], 
-					'height'  => [], 
-					'viewbox' => [], //lowercase not camelcase!
-				], 
+					'xmlns'       => [],
+					'width'       => [],
+					'height'      => [],
+					'viewbox'     => [], //lowercase not camelcase!
+					'fill'        => [],
+					'aria-hidden' => [],
+					'role'        => [],
+					'focusable'   => [],
+					'class'       => [],
+				],
 				'path'     => [
-					'd' => [],
+					'd'         => [],
+					'fill'      => [],
+					'fill-rule' => [],
+					'clip-rule' => [],
+					'clip-path' => [],
 				],
 				'g'        => [
-					'path' => [],
+					'path'      => [],
+					'fill'      => [],
+					'clip-path' => [],
 				],
 				'defs'     => [],
-				'clippath' => [],
+				'clippath' => [
+					'id' => [],
+				],
 				
 			]
 		);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -45,6 +45,7 @@
 			<element value="get_block_wrapper_attributes" />
 			<element value="gp_line_attributes" />
 			<element value="gp_get_the_status_terms_list" />
+			<element value="gp_maybe_link" />
 		</property>
 	</properties>
 </rule>

--- a/src/blocks/ProfileField.php
+++ b/src/blocks/ProfileField.php
@@ -227,9 +227,9 @@ abstract class ProfileField extends \Govpack\Abstracts\Block implements ProfileF
 		$attributes = array_map(
 			function ( $key, $value ) {
 				return sprintf(
-					'%s="%s"', 
-					trim( $key ), 
-					trim( $value )
+					'%s="%s"',
+					trim( $key ),
+					esc_attr( trim( $value ) )
 				);
 			}, 
 			array_keys( $args ), 

--- a/src/blocks/ProfileFieldLink.php
+++ b/src/blocks/ProfileFieldLink.php
@@ -72,9 +72,7 @@ class ProfileFieldLink extends \Govpack\Blocks\ProfileFieldText {
 	}
 
 	/**
-	 * The anchor's inner content, escaped for the format it takes: the icon
-	 * format returns SVG markup and goes through esc_svg(), every other format
-	 * is text and goes through esc_html().
+	 * The anchor's inner content, already escaped for the format it takes.
 	 */
 	public function linkText(): string {
 		$link = $this->get_value();

--- a/src/blocks/ProfileFieldLink.php
+++ b/src/blocks/ProfileFieldLink.php
@@ -35,7 +35,7 @@ class ProfileFieldLink extends \Govpack\Blocks\ProfileFieldText {
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => $this->get_css_class( $attributes ) ] );
 		?>
 		<div <?php echo $wrapper_attributes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<?php echo $this->output();  //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php echo $this->output(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- output() escapes each operand before assembling the anchor. ?>
 		</div>
 		<?php
 	}
@@ -68,9 +68,14 @@ class ProfileFieldLink extends \Govpack\Blocks\ProfileFieldText {
 			$url = 'https://' . $url;
 		}
 		
-		return sprintf( '<a href="%s">%s</a>', $url, $this->linkText() );
+		return sprintf( '<a href="%s">%s</a>', esc_url( $url ), $this->linkText() );
 	}
 
+	/**
+	 * The anchor's inner content, escaped for the format it takes: the icon
+	 * format returns SVG markup and goes through esc_svg(), every other format
+	 * is text and goes through esc_html().
+	 */
 	public function linkText(): string {
 		$link = $this->get_value();
 
@@ -79,19 +84,19 @@ class ProfileFieldLink extends \Govpack\Blocks\ProfileFieldText {
 		$default_label      = $has_default_label ? $link['linkText'] : 'Link';
 		
 		if ( $this->attribute( 'linkFormat' ) === 'url' ) {
-			return $link['url'] ?? '';
+			return esc_html( $link['url'] ?? '' );
 		}
 
 		if ( $this->attribute( 'linkFormat' ) === 'label' ) {
-			return ( $has_label_override ? $this->attribute( 'linkTextOverride' ) : $default_label );
+			return esc_html( $has_label_override ? $this->attribute( 'linkTextOverride' ) : $default_label );
 		}
 
 		if ( $this->attribute( 'linkFormat' ) === 'icon' ) {
-			return $this->get_field()->icon_markup() ?? '';
+			return esc_svg( $this->get_field()->icon_markup() ?? '' );
 		}
 
 
-		return $default_label;
+		return esc_html( $default_label );
 	}
 
 	public function variations(): array {

--- a/src/blocks/ProfileName.php
+++ b/src/blocks/ProfileName.php
@@ -48,9 +48,12 @@ class ProfileName extends \Govpack\Blocks\ProfileFieldText {
 
 	public function output(): string {
 
-		// If we're not outputting a link then just use the output as normal
+		// The name is text on both paths; escape it here so the anchor below
+		// is assembled from escaped operands rather than relying on kses.
+		$name = esc_html( parent::output() );
+
 		if ( ! $this->attribute( 'isLink' ) ) {
-			return parent::output();
+			return $name;
 		}
 
 		// Great an array of html attributes for the link
@@ -63,7 +66,7 @@ class ProfileName extends \Govpack\Blocks\ProfileFieldText {
 			$link_attrs['rel'] = $this->attribute( 'rel' );
 		}
 
-		return sprintf( '<a %s>%s</a>', self::array_to_html_attributes( $link_attrs ), parent::output() );
+		return sprintf( '<a %s>%s</a>', self::array_to_html_attributes( $link_attrs ), $name );
 	}
 
 	

--- a/src/blocks/ProfileName.php
+++ b/src/blocks/ProfileName.php
@@ -59,7 +59,7 @@ class ProfileName extends \Govpack\Blocks\ProfileFieldText {
 		// Great an array of html attributes for the link
 		$link_attrs = [
 			'target' => $this->attribute( 'linkTarget' ),
-			'href'   => $this->get_profile()->permalink(),
+			'href'   => esc_url( $this->get_profile()->permalink() ),
 		];
 
 		if ( $this->attribute( 'rel' ) ) {

--- a/src/blocks/ProfileReadMore.php
+++ b/src/blocks/ProfileReadMore.php
@@ -54,7 +54,7 @@ class ProfileReadMore extends \Govpack\Blocks\ProfileFieldText {
 		// Great an array of html attributes for the link
 		$link_attrs = [
 			'target' => $this->attribute( 'linkTarget' ),
-			'href'   => $this->get_profile()->permalink(),
+			'href'   => esc_url( $this->get_profile()->permalink() ),
 		];
 
 		if ( $this->attribute( 'rel' ) ) {

--- a/src/blocks/ProfileReadMore.php
+++ b/src/blocks/ProfileReadMore.php
@@ -61,7 +61,7 @@ class ProfileReadMore extends \Govpack\Blocks\ProfileFieldText {
 			$link_attrs['rel'] = $this->attribute( 'rel' );
 		}
 
-		$link_text = $this->attribute( 'linkText' );
+		$link_text = esc_html( $this->attribute( 'linkText' ) ?? '' );
 		$prefix    = $this->attribute( 'prefixWithName' ) ? esc_html( $this->get_profile()->value( 'name' ) ) : '';
 		$suffix    = $this->attribute( 'suffixWithName' ) ? esc_html( $this->get_profile()->value( 'name' ) ) : '';
 		$link_text = trim( sprintf( '%s %s %s', $prefix, $link_text, $suffix ) );

--- a/src/blocks/ProfileReadMore.php
+++ b/src/blocks/ProfileReadMore.php
@@ -62,8 +62,8 @@ class ProfileReadMore extends \Govpack\Blocks\ProfileFieldText {
 		}
 
 		$link_text = $this->attribute( 'linkText' );
-		$prefix    = $this->attribute( 'prefixWithName' ) ? $this->get_profile()->value( 'name' ) : '';
-		$suffix    = $this->attribute( 'suffixWithName' ) ? $this->get_profile()->value( 'name' ) : '';
+		$prefix    = $this->attribute( 'prefixWithName' ) ? esc_html( $this->get_profile()->value( 'name' ) ) : '';
+		$suffix    = $this->attribute( 'suffixWithName' ) ? esc_html( $this->get_profile()->value( 'name' ) ) : '';
 		$link_text = trim( sprintf( '%s %s %s', $prefix, $link_text, $suffix ) );
 		
 

--- a/templates/blocks/parts/profile-photo.php
+++ b/templates/blocks/parts/profile-photo.php
@@ -12,7 +12,7 @@ $profile_block = $extra['profile_block'];
 if ( $profile_block->show( 'photo' ) ) { ?>
 	<div class="wp-block-govpack-profile__avatar">
 		<figure class="govpack-photo" style="<?php echo esc_attr( gp_get_photo_styles( $attributes ) ); ?>">
-			<?php echo wp_kses_post( GP_Maybe_Link( get_the_post_thumbnail( $profile_data['id'], 'post-thumbnail', [ 'class' => 'govpack-photo-image' ] ), $profile_data['link'], false ) ); ?>
+			<?php echo wp_kses_post( get_the_post_thumbnail( $profile_data['id'], 'post-thumbnail', [ 'class' => 'govpack-photo-image' ] ) ); ?>
 		</figure>
 	</div>
 	<?php

--- a/templates/blocks/parts/row-more-link.php
+++ b/templates/blocks/parts/row-more-link.php
@@ -7,6 +7,4 @@ if ( ! $profile_block->show( 'profile_link' ) ) {
 	return;
 }
 
-$more_link = sprintf( '<a href="%s">%s %s</a>', $profile_data['link'], 'More About', $profile_data['name']['name'] );
-
-echo wp_kses_post( $more_link );
+echo gp_maybe_link( sprintf( 'More About %s', $profile_data['name']['name'] ), $profile_data['link'], true );

--- a/templates/blocks/parts/row-more-link.php
+++ b/templates/blocks/parts/row-more-link.php
@@ -7,4 +7,9 @@ if ( ! $profile_block->show( 'profile_link' ) ) {
 	return;
 }
 
-echo gp_maybe_link( sprintf( 'More About %s', $profile_data['name']['name'] ), $profile_data['link'], true );
+echo gp_maybe_link(
+	/* translators: %s: the profile's name. */
+	sprintf( __( 'More About %s', 'newspack-elections' ), $profile_data['name']['name'] ),
+	$profile_data['link'],
+	true
+);

--- a/templates/blocks/profile.php
+++ b/templates/blocks/profile.php
@@ -56,7 +56,7 @@ echo get_block_wrapper_attributes(
 			<?php if ( $profile_block->show( 'name' ) || $profile_block->show( 'status_tag' ) ) { ?>
 				<div class="wp-block-govpack-profile__line wp-block-govpack-profile--flex-left">
 				<?php if ( $profile_block->show( 'name' ) ) { ?>
-					<h3 class="wp-block-govpack-profile__name"> <?php echo GP_Maybe_Link( $profile_data['name']['name'], $profile_data['link'], $attributes['showProfileLink'] );  //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h3>
+					<h3 class="wp-block-govpack-profile__name"> <?php echo gp_maybe_link( $profile_data['name']['name'], $profile_data['link'], $attributes['showProfileLink'] ); ?></h3>
 				<?php } ?>
 				<?php if ( $profile_block->show( 'status_tag' ) ) { ?>
 					<div class="wp-block-govpack-profile__status-tag">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-workspace/blob/main/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Profile fields are post meta, and a handful of template helpers turn them into block markup. Every one of those helpers now escapes at the point of output, so a field renders as text whatever it holds, and the lint rule holds that contract at each call site instead of a `phpcs:ignore`.

The escaping lives in `gp_maybe_link()` rather than at each caller because the helper already owned the URL half of the anchor, and one owner for the whole anchor is easier to hold to. Its contract is plain text in, safe HTML out, on the linked and unlinked paths alike, and PHPCS knows it as an escaping function. The one caller that handed it markup, the photo template, calls `get_the_post_thumbnail()` directly, which is all that call did. The newer field blocks that build anchors from meta (`ProfileFieldLink`, `ProfileReadMore`) and the legacy "More about" row follow the same rule.

The helper is a theme-overridable template tag, so this narrows its contract for any theme copy of a profile template that still hands it markup; those copies render the markup as text until they call the underlying function directly.

A second helper for markup content was considered and rejected: it would add an API to serve one call site that does not need it. The `ProfileFieldLink` render keeps its `phpcs:ignore`, with the reason inline: PHPCS cannot allowlist a method call, and `wp_kses_post()` around the echo would strip the icon format's SVG (the wrapper-attributes ignore beside it is pre-existing and unchanged).

NPPM-3195

### How to test the changes in this Pull Request:

This repo has no PHPUnit suite, so we checked it on an isolated env. A profile rendered through both the `govpack/profile` and `npe/profile` block families shows each field as text, and the photo, status tags, contact link, and "More about" link render as before. PHPCS passes on every changed file.

![Profile blocks rendering an ordinary profile: name, contact link, and More About link](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/05/lhqpm54g-nppm-3195-profile-blocks.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? n/a: the repo has no test harness; verified on an env as above.
* [ ] Have you successfully ran tests with your changes locally? n/a, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

